### PR TITLE
Fix: localizations are removed after translating

### DIFF
--- a/__mocks__/contentTypes.js
+++ b/__mocks__/contentTypes.js
@@ -25,7 +25,8 @@ function createRelationContentType(
   relationType,
   inverseOrMapped,
   translated,
-  target
+  target,
+  uid = 'api::first.first'
 ) {
   return {
     pluginOptions: {
@@ -41,6 +42,15 @@ function createRelationContentType(
         target: target,
         ...inverseOrMapped,
       },
+      ...(translated
+        ? {
+            localizations: {
+              type: 'relation',
+              relation: 'oneToMany',
+              target: uid,
+            },
+          }
+        : {}),
     },
   }
 }

--- a/server/utils/translate-relations.js
+++ b/server/utils/translate-relations.js
@@ -95,7 +95,7 @@ async function translateRelation(attributeData, attributeSchema, targetLocale) {
     // for oneToMany and manyToMany relations there are multiple relations possible, so all of them need to be considered
     if (
       ['oneToMany', 'manyToMany'].includes(attributeSchema.relation) &&
-      attributeData.length > 0
+      attributeData?.length > 0
     ) {
       return _.compact(
         await Promise.all(

--- a/server/utils/translate-relations.js
+++ b/server/utils/translate-relations.js
@@ -24,6 +24,10 @@ async function translateRelations(data, schema, targetLocale) {
   const resultData = _.cloneDeep(data)
   await Promise.all(
     Object.keys(attributesSchema).map(async (attr) => {
+      if (attr === 'localizations') {
+        return true
+      }
+
       const attributeSchema = attributesSchema[attr]
 
       if (attributeSchema.type === 'relation') {

--- a/server/utils/translate-relations.js
+++ b/server/utils/translate-relations.js
@@ -18,7 +18,8 @@ async function getRelevantLocalization(contentType, id, locale) {
  *  - translated if the relation target is localized and the related instance has the targetLocale created
  */
 async function translateRelations(data, schema, targetLocale) {
-  const { translateRelations: shouldTranslateRelations } = strapi.config.get('plugin.deepl')
+  const { translateRelations: shouldTranslateRelations } =
+    strapi.config.get('plugin.deepl')
 
   const attributesSchema = _.get(schema, 'attributes', [])
   const resultData = _.cloneDeep(data)
@@ -31,11 +32,13 @@ async function translateRelations(data, schema, targetLocale) {
       const attributeSchema = attributesSchema[attr]
 
       if (attributeSchema.type === 'relation') {
-        resultData[attr] = shouldTranslateRelations ? await translateRelation(
-          _.get(data, attr, undefined),
-          attributeSchema,
-          targetLocale
-        ) : undefined
+        resultData[attr] = shouldTranslateRelations
+          ? await translateRelation(
+              _.get(data, attr, undefined),
+              attributeSchema,
+              targetLocale
+            )
+          : undefined
       } else if (attributeSchema.type === 'component') {
         resultData[attr] = await translateComponent(
           _.get(data, attr, undefined),
@@ -83,13 +86,6 @@ async function translateRelation(attributeData, attributeSchema, targetLocale) {
     _.has(attributeSchema, 'inversedBy', false) ||
     _.has(attributeSchema, 'mappedBy', false)
 
-  strapi.log.debug(
-    JSON.stringify([
-      attributeSchema.relation,
-      relationIsLocalized,
-      relationIsBothWays,
-    ])
-  )
   // If the relation is localized, the relevant localizations from the relation should be selected
   if (relationIsLocalized) {
     // for oneToMany and manyToMany relations there are multiple relations possible, so all of them need to be considered


### PR DESCRIPTION
fixes #4 

This fixes localizations being removed after translating an entity.

The reason for this happening is that localizations are stored as relation in the schema, and are being removed by the `translateRelations` method