### PR TITLE
fix: 413 Error when fields are too large

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 ## Requirements
 
 This plugin requires the following, in order to work correctly:
+
 - Strapi v4 (this plugin is not compatible with v3)
 - The plugin **i18n** installed and enabled (`@strapi/plugin-i18n` [[npm](https://www.npmjs.com/package/@strapi/plugin-i18n)])
 - The content type to have internationalization enabled (advanced settings in the content type builder)
@@ -32,6 +33,7 @@ This plugin requires the following, in order to work correctly:
 Unless you have the previous set up, the field on the right where you can translate will not show up. Also it will not show up when editing the currently only available translation of an entry.
 
 ## Installation
+
 ```bash
 # with npm
 $ npm install strapi-plugin-deepl
@@ -114,6 +116,7 @@ To get an API key, register for free at [www.deepl.com/pro#developer](https://ww
 - HTML in `richtext` created using a different WYSIWYG editor is not supported
 - **Only super admins can translate**. This is currently the case, since permissions were added to the `translate` endpoint. Probably you can change the permissions with an enterprise subscription but I am not sure. If you know how to do that also in the community edition please tell me or open a merge request!
 - Relations that do not have a translation of the desired locale will not be translated. To keep the relation you will need to translate both in succession (Behaviour for multi-relations has not yet been analyzed)
+- The API-Limits of DeepL ([size](https://www.deepl.com/de/docs-api/accessing-the-api/limits/) and [number of fields](https://www.deepl.com/de/docs-api/translating-text/request/)) should not be an issue, however if you have a very large entity you might be sending too many requests. Also if one field is larger than the reqest size limit, the content needs to be split and merged at some character, which may break the content layout!
 
 ## Legal Disclaimer
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "url": "https://github.com/Fekide/strapi-plugin-deepl/issues"
   },
   "devDependencies": {
+    "@faker-js/faker": "^6.2.0",
     "@strapi/plugin-i18n": "^4.1.5",
     "axios-mock-adapter": "^1.20.0",
     "jest": "^27.5.1"

--- a/server/utils/__tests__/deepl-api.test.js
+++ b/server/utils/__tests__/deepl-api.test.js
@@ -129,8 +129,10 @@ describe('deepl api', () => {
     describe.each([true, false])('for free api %p', (freeApi) => {
       beforeEach(() => {
         const translateHandler = (config) => {
-          if (stringByteLength(config.data) > DEEPL_API_MAX_REQUEST_SIZE) {
-            console.log({ length: stringByteLength(config.data) })
+          if (
+            stringByteLength(config.data || '') > DEEPL_API_MAX_REQUEST_SIZE
+          ) {
+            console.log({ length: stringByteLength(config.data || '') })
             return [413]
           }
           const params = new URLSearchParams(config.data)

--- a/server/utils/__tests__/deepl-api.test.js
+++ b/server/utils/__tests__/deepl-api.test.js
@@ -1,13 +1,19 @@
 const axios = require('axios')
 const MockAdapter = require('axios-mock-adapter')
+const faker = require('@faker-js/faker').default
 
-const { DEEPL_FREE_API, DEEPL_PAID_API } = require('../constants')
+const {
+  DEEPL_FREE_API,
+  DEEPL_PAID_API,
+  DEEPL_API_MAX_REQUEST_SIZE,
+} = require('../constants')
 
 const { URLSearchParams } = require('url')
 
 const { usage, translate, parseLocale } = require('../deepl-api')
 
 const locales = require('@strapi/plugin-i18n/server/constants/iso-locales.json')
+const { stringByteLength } = require('../byte-length')
 
 function supportedLocale({ code, name }) {
   // Swiss German is not supported
@@ -51,6 +57,11 @@ describe('deepl api', () => {
 
   beforeAll(() => {
     mock = new MockAdapter(axios)
+
+    Object.defineProperty(global, 'strapi', {
+      value: require('../../../__mocks__/initSetup')({}),
+      writable: true,
+    })
   })
 
   afterEach(() => {
@@ -118,6 +129,10 @@ describe('deepl api', () => {
     describe.each([true, false])('for free api %p', (freeApi) => {
       beforeEach(() => {
         const translateHandler = (config) => {
+          if (stringByteLength(config.data) > DEEPL_API_MAX_REQUEST_SIZE) {
+            console.log({ length: stringByteLength(config.data) })
+            return [413]
+          }
           const params = new URLSearchParams(config.data)
           if (params.get('auth_key') == authKey) {
             let text = params.getAll('text')
@@ -246,6 +261,113 @@ describe('deepl api', () => {
 
         it('with more than 50 texts', async () => {
           await forMoreThan50Texts(freeApi)
+        })
+
+        it('with all fields together more than request size limit', async () => {
+          // given
+          const textLength = 40
+          const params = {
+            free_api: freeApi,
+            auth_key: authKey,
+            target_lang: 'DE',
+            text: faker.helpers.uniqueArray(
+              () => faker.lorem.paragraphs(20),
+              textLength
+            ),
+          }
+          // when
+          const result = await translate(params)
+
+          // then
+          expect(mock.history.post.length).toBeGreaterThan(1)
+          expect(result).toEqual({
+            translations: params.text.map((t) => ({
+              detected_source_language: 'EN',
+              text: t,
+            })),
+          })
+        })
+
+        it('with a field larger than request size limit', async () => {
+          // given
+          const textLength = 1
+          const params = {
+            free_api: freeApi,
+            auth_key: authKey,
+            target_lang: 'DE',
+            text: [faker.lorem.paragraphs(DEEPL_API_MAX_REQUEST_SIZE / 200)],
+          }
+          // when
+          const result = await translate(params)
+
+          // then
+          expect(mock.history.post.length).toBeGreaterThan(1)
+          expect(result).toEqual({
+            translations: params.text.map((t) => ({
+              detected_source_language: 'EN',
+              text: t,
+            })),
+          })
+        })
+
+        it.skip('with fields larger than request size limit count of new lines preserved', async () => {
+          // given
+          const textLength = 10
+          const params = {
+            free_api: freeApi,
+            auth_key: authKey,
+            target_lang: 'DE',
+            text: faker.helpers.uniqueArray(
+              () =>
+                faker.lorem.paragraphs(
+                  DEEPL_API_MAX_REQUEST_SIZE / 200,
+                  '\n'.repeat(faker.datatype.number({ min: 1, max: 3 }))
+                ),
+              textLength
+            ),
+          }
+          // when
+          const result = await translate(params)
+
+          // then
+          expect(mock.history.post.length).toBeGreaterThan(1)
+          expect(result).toEqual({
+            translations: params.text.map((t) => ({
+              detected_source_language: 'EN',
+              text: t,
+            })),
+          })
+        })
+
+        it('with some fields larger than request size limit', async () => {
+          // given
+          const textLength = 20
+          const params = {
+            free_api: freeApi,
+            auth_key: authKey,
+            target_lang: 'DE',
+            text: faker.helpers.uniqueArray(
+              () =>
+                faker.lorem.paragraphs(
+                  faker.datatype.number({
+                    min: DEEPL_API_MAX_REQUEST_SIZE / 2000,
+                    max: DEEPL_API_MAX_REQUEST_SIZE / 200,
+                  })
+                ),
+              textLength
+            ),
+          }
+          // when
+          const result = await translate(params)
+
+          // then
+          expect(mock.history.post.length).toBeGreaterThan(1)
+          expect(result).toEqual({
+            translations: params.text.map((t) => ({
+              detected_source_language: 'EN',
+              text: t,
+            })),
+          })
         })
       })
 

--- a/server/utils/byte-length.js
+++ b/server/utils/byte-length.js
@@ -1,0 +1,12 @@
+'use strict'
+
+/**
+ * Calculate the length of a string in byte when it is encoded using `encodeURI`
+ * @param {string} string String to get the byte length for
+ * @returns The length of the string in bytes when encoded using `encodeURI`
+ */
+function stringByteLength(string) {
+  return Buffer.byteLength(encodeURI(string), 'utf8')
+}
+
+module.exports = { stringByteLength }

--- a/server/utils/byte-length.js
+++ b/server/utils/byte-length.js
@@ -6,7 +6,11 @@
  * @returns The length of the string in bytes when encoded using `encodeURI`
  */
 function stringByteLength(string) {
-  return Buffer.byteLength(encodeURI(string), 'utf8')
+  return Buffer.byteLength(string, 'utf8')
 }
 
-module.exports = { stringByteLength }
+function stringByteLengthEncoded(string) {
+  return stringByteLength(encodeURI(string))
+}
+
+module.exports = { stringByteLength, stringByteLengthEncoded }

--- a/server/utils/chunks.js
+++ b/server/utils/chunks.js
@@ -1,0 +1,146 @@
+'use strict'
+
+const { stringByteLength } = require('./byte-length')
+const {
+  DEEPL_API_MAX_TEXTS,
+  DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
+} = require('./constants')
+
+/**
+ * Splits the given array of strings into chunks a maximum length
+ * and each chunk beaing at most a specific byte size.
+ *
+ * @param {string[]} textArray
+ * @param {{maxLength: number, maxByteSize: number}} options Configuration options
+ * @returns
+ */
+function splitTextArrayIntoChunks(
+  textArray,
+  {
+    maxLength = DEEPL_API_MAX_TEXTS,
+    maxByteSize = DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
+  } = {
+    maxLength: DEEPL_API_MAX_TEXTS,
+    maxByteSize: DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
+  }
+) {
+  // Information about how to join chunks back together
+  const reduceInformation = []
+
+  const chunkedText = [[]]
+  // The index of the current Chunk
+  let chunkIndex = 0
+  // The total byte length of the current chunk (only the text)
+  let currentChunkByteLength = 0
+
+  // Utility to progress to the next chunk
+  const nextChunk = () => {
+    chunkIndex++
+    currentChunkByteLength = 0
+    chunkedText.push([])
+  }
+
+  // Iterate over all texts and decide if:
+  // - the string can be added to the current chunk
+  // - the string needs to be added to a new chunk
+  // - the string itself is too big and needs to be split before it can be put into chunks
+  textArray.forEach((textField) => {
+    const fieldByteLength = stringByteLength(textField)
+    if (fieldByteLength > maxByteSize) {
+      strapi.log.warn(
+        'There is a field being translated, that is itself longer than the maxByteSize parameter. ' +
+          'This may result in issues because the field content needs to be split into multiple requests!' +
+          'Splitting is currently achieved by splitting at one or multiple new lines and joining back together with one new line.'
+      )
+
+      // FIXME: Splitting at multiple newlines might be breaking content layout
+      const splitTextField = textField.split(/\n+/)
+
+      // Recursively call this method to split the array into chunks of appropriate length and size
+      const { chunks } = splitTextArrayIntoChunks(splitTextField)
+
+      if (chunkedText[chunkIndex].length === 0) {
+        // When we are at the beginning or after another too big field, there will be a new empty chunk
+        chunkedText.pop()
+      } else {
+        // If the current chunk is not empty, strings were added that were not too long. So the next chunk must be selected
+        reduceInformation.push({ type: 'append', index: chunkIndex })
+        chunkIndex++
+      }
+
+      // Add the splitted chunks and add the information that these need to be joined together
+      chunkedText.push(...chunks)
+      reduceInformation.push({
+        type: 'join',
+        from: chunkIndex,
+        to: chunkIndex + chunks.length,
+      })
+      chunkIndex += chunks.length - 1
+      nextChunk()
+    } else {
+      if (
+        chunkedText[chunkIndex].length >= maxLength ||
+        currentChunkByteLength + fieldByteLength >= maxByteSize
+      ) {
+        reduceInformation.push({ type: 'append', index: chunkIndex })
+        nextChunk()
+      }
+      currentChunkByteLength += fieldByteLength
+      chunkedText[chunkIndex].push(textField)
+    }
+  })
+
+  if (chunkedText[chunkIndex].length === 0) {
+    // Pop the last empty chunk if the last text was too large
+    chunkedText.pop()
+  } else {
+    // Otherwise the last chunk needs to be appended
+    reduceInformation.push({ type: 'append', index: chunkIndex })
+  }
+
+  const reduceFunction = (translationResults) => {
+    return reduceInformation.reduce(
+      (prev, { type, ...props }) => {
+        if (type === 'append' && 'index' in props) {
+          // Just concatenate the translation texts in the append case
+          return {
+            translations: prev.translations.concat(
+              translationResults[props.index].translations
+            ),
+          }
+        } else if (type === 'join' && 'from' in props && 'to' in props) {
+          const joinedText = translationResults
+            // Get all of the relevant chunks for joining
+            .slice(props.from, props.to)
+            // Get the translations
+            .map((v) => v.translations)
+            .flat()
+            .reduce((prev, cur) => {
+              return {
+                detected_source_language: cur.detected_source_language,
+                // FIXME: Adding the texts back together with only a new line might be breaking content layout
+                text: prev.text ? prev.text + '\n' + cur.text : cur.text,
+              }
+            }, {})
+          return {
+            translations: prev.translations.concat(joinedText),
+          }
+        } else {
+          throw new Error(
+            `Unrecognized props for reducing: ${JSON.stringify({
+              type,
+              ...props,
+            })}`
+          )
+        }
+      },
+      { translations: [] }
+    )
+  }
+
+  return { chunks: chunkedText, reduceFunction }
+}
+
+module.exports = {
+  splitTextArrayIntoChunks,
+}

--- a/server/utils/chunks.js
+++ b/server/utils/chunks.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { stringByteLength } = require('./byte-length')
+const { stringByteLengthEncoded } = require('./byte-length')
 const {
   DEEPL_API_MAX_TEXTS,
   DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
@@ -16,10 +16,7 @@ const {
  */
 function splitTextArrayIntoChunks(
   textArray,
-  {
-    maxLength = DEEPL_API_MAX_TEXTS,
-    maxByteSize = DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
-  } = {
+  { maxLength, maxByteSize } = {
     maxLength: DEEPL_API_MAX_TEXTS,
     maxByteSize: DEEPL_API_ROUGH_MAX_REQUEST_SIZE,
   }
@@ -45,7 +42,7 @@ function splitTextArrayIntoChunks(
   // - the string needs to be added to a new chunk
   // - the string itself is too big and needs to be split before it can be put into chunks
   textArray.forEach((textField) => {
-    const fieldByteLength = stringByteLength(textField)
+    const fieldByteLength = stringByteLengthEncoded(textField)
     if (fieldByteLength > maxByteSize) {
       strapi.log.warn(
         'There is a field being translated, that is itself longer than the maxByteSize parameter. ' +

--- a/server/utils/constants.js
+++ b/server/utils/constants.js
@@ -2,4 +2,7 @@ module.exports = {
   DEEPL_FREE_API: 'https://api-free.deepl.com/v2',
   DEEPL_PAID_API: 'https://api.deepl.com/v2',
   DEEPL_API_MAX_TEXTS: 50,
+  DEEPL_API_MAX_REQUEST_SIZE: 131072,
+  // Lower to account for additional information in post data
+  DEEPL_API_ROUGH_MAX_REQUEST_SIZE: 130000,
 }

--- a/server/utils/deepl-api.js
+++ b/server/utils/deepl-api.js
@@ -35,9 +35,9 @@ async function translate({ text, free_api, glossary_id, ...parameters }) {
       chunks.map(async (texts) => {
         const requestParams = new URLSearchParams(params)
         texts.forEach((t) => requestParams.append('text', t))
-        return (
-          await axios.post(`${apiURL}/translate`, requestParams.toString())
-        ).data
+        const requestParamsString = requestParams.toString()
+        return (await axios.post(`${apiURL}/translate`, requestParamsString))
+          .data
       })
     )
   )

--- a/server/utils/deepl-api.js
+++ b/server/utils/deepl-api.js
@@ -5,11 +5,8 @@ const axios = require('axios')
 
 const _ = require('lodash')
 
-const {
-  DEEPL_FREE_API,
-  DEEPL_PAID_API,
-  DEEPL_API_MAX_TEXTS,
-} = require('./constants')
+const { DEEPL_FREE_API, DEEPL_PAID_API } = require('./constants')
+const { splitTextArrayIntoChunks } = require('./chunks')
 
 async function usage({ free_api, ...parameters }) {
   const apiURL = free_api ? DEEPL_FREE_API : DEEPL_PAID_API
@@ -30,11 +27,12 @@ async function translate({ text, free_api, glossary_id, ...parameters }) {
   }
 
   const textArray = Array.isArray(text) ? text : [text]
-  const chunkedText = _.chunk(textArray, DEEPL_API_MAX_TEXTS)
 
-  return (
+  const { chunks, reduceFunction } = splitTextArrayIntoChunks(textArray)
+
+  return reduceFunction(
     await Promise.all(
-      chunkedText.map(async (texts) => {
+      chunks.map(async (texts) => {
         const requestParams = new URLSearchParams(params)
         texts.forEach((t) => requestParams.append('text', t))
         return (
@@ -42,13 +40,6 @@ async function translate({ text, free_api, glossary_id, ...parameters }) {
         ).data
       })
     )
-  ).reduce(
-    (prev, cur) => {
-      return {
-        translations: [...prev.translations, ...cur.translations],
-      }
-    },
-    { translations: [] }
   )
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,11 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@faker-js/faker@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@faker-js/faker/-/faker-6.2.0.tgz#6d836ee8a580589b60c9088a3bdb0b669a468825"
+  integrity sha512-3kIcQ+aTr3I+LqDbJwbINFk5oA+a63LH57GPJt9PM8AWqN7nCwnubuSiWosHYQlyf2NicrvpzXQxllyLeEdpyQ==
+
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz#fd3db1d59ecf7cf121e80650bb86712f9b55eced"


### PR DESCRIPTION
improve the splitting of text into chunks by having three options
- append text to current chunk
- add text to new chunk if
  - more than 50 texts in the chunk (was possible before)
  - chunks byte size is too large (new feature)
- split text into multiple texts if it is itself larger than the request size
  (new feature but not necessarily safe for content layout)

fixes #8 