### PR TITLE
Fix `npm` warnings about incompatible engine versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "maintainers": [],
   "engines": {
-    "node": ">=12.x. <=16.x.x",
+    "node": ">=12 <=16",
     "npm": ">=6.0.0"
   },
   "license": "MIT",


### PR DESCRIPTION
When installing `strapi-plugin-deepl`, npm emits a warning:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'strapi-plugin-deepl@0.3.8',
npm WARN EBADENGINE   required: { node: '>=12.x. <=16.x.x', npm: '>=6.0.0' },
npm WARN EBADENGINE   current: { node: 'v16.18.0', npm: '8.19.2' }
npm WARN EBADENGINE }
```

The problem is the dot in `>=12.x.`. Removing `.x.` and `.x.x` completely should be fully equivalent.