### PR TITLE
feat: handle format of text field types

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="assets/logo.svg" alt="alt="Strapi-Translate" width="300" height="150" />
+  <img src="assets/logo.svg" alt="Strapi-Translate" width="300" height="150" />
 </p>
 
 <div align="center">
@@ -69,10 +69,12 @@ module.exports = {
         // Your provider might define some custom options like an apiKey
       },
       // Which field types are translated (default string, text, richtext, components and dynamiczones)
+      // Either string or object with type and format
+      // Possible formats: plain, markdown, html (default plain)
       translatedFieldTypes: [
         'string',
-        'text',
-        'richtext',
+        { type: 'text', format: 'plain' },
+        { type: 'richtext', format: 'markdown' },
         'component',
         'dynamiczone',
       ],
@@ -204,7 +206,13 @@ module.exports = {
 
     return {
       /**
-       * @param {{text:string|string[], sourceLocale: string, targetLocale: string, priority: number}} options all translate options
+       * @param {{
+       *  text:string|string[],
+       *  sourceLocale: string,
+       *  targetLocale: string,
+       *  priority: number,
+       *  format?: 'plain'|'markdown'|'html'
+       * }} options all translate options
        * @returns {string[]} the input text(s) translated
        */
       async translate(options) {
@@ -243,10 +251,22 @@ return reduceFunction(
 )
 ```
 
+The translate function receives the format of the text as `plain`, `markdown` or `html`. If your translation provider supports only html, but no markdown, you can use the `format` service to change the format before translating to `html` and afterwards back to `markdown`:
+
+```js
+const { markdownToHtml, htmlToMarkdown } = strapi.service(
+  'plugin::translate.format'
+)
+
+if (format === 'markdown') {
+  return htmlToMarkdown(providerClient.translateTexts(markdownToHtml(text)))
+}
+return providerClient.translateTexts(texts)
+```
+
 ## (Current) Limitations:
 
-- The translation of Markdown using the DeepL-Provider works relatively well but is not perfect. Watch out especially if you have links in Markdown that could be changed by translation
-- HTML in `richtext` created using a different WYSIWYG editor is not supported
+- The translation of Markdown and HTML may vary between different providers
 - **Only super admins can translate**. This is currently the case, since permissions were added to the `translate` endpoint. Probably you can change the permissions with an enterprise subscription but I am not sure. If you know how to do that also in the community edition please tell me or open a merge request!
 - Relations that do not have a translation of the desired locale will not be translated. To keep the relation you will need to translate both in succession (Behaviour for multi-relations has not yet been analyzed)
 

--- a/plugin/__mocks__/components.js
+++ b/plugin/__mocks__/components.js
@@ -9,7 +9,7 @@ function createSimpleComponent(translate = 'translate') {
             translate,
           },
         },
-        type: 'text',
+        type: 'richtext',
       },
     },
   }

--- a/plugin/__mocks__/initSetup.js
+++ b/plugin/__mocks__/initSetup.js
@@ -1,6 +1,7 @@
-const { get, set, isEmpty } = require('lodash')
+const { get, set, isEmpty, defaults } = require('lodash')
 
 const dummyProvider = require('../server/utils/dummy-provider')
+const configModule = require('../server/config')
 
 module.exports = ({
   config = {},
@@ -23,6 +24,9 @@ module.exports = ({
         },
       }
     : {}
+
+  defaults(config, configModule.default())
+  configModule.validator(config)
 
   let mock = {
     db: {
@@ -94,6 +98,7 @@ module.exports = ({
         services: {
           provider: require('../server/services/provider'),
           translate: require('../server/services/translate'),
+          format: require('../server/services/format'),
           'batch-translate-job': () => {
             const uid = 'plugin::translate.batch-translate-job'
             return {
@@ -143,17 +148,8 @@ module.exports = ({
       },
       plugins: {
         translate: {
-          provider: provider.provider,
-          translatedFieldTypes: [
-            'string',
-            'text',
-            'richtext',
-            'component',
-            'dynamiczone',
-          ],
-          translateRelations: true,
-          glossaryId: null,
-          ...(toStore ? {} : config),
+          ...config,
+          provider: provider?.provider,
         },
       },
     },

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "axios": "^0.26.0",
-    "bottleneck": "^2.19.5"
+    "bottleneck": "^2.19.5",
+    "jsdom": "^20.0.2",
+    "showdown": "^2.1.0"
   },
   "peerDependencies": {
     "@strapi/plugin-i18n": "^4.1.4",

--- a/plugin/server/config/__tests__/config.test.js
+++ b/plugin/server/config/__tests__/config.test.js
@@ -1,0 +1,82 @@
+'use strict'
+
+const setup = function (params) {
+  Object.defineProperty(global, 'strapi', {
+    value: require('../../../__mocks__/initSetup')(params),
+    writable: true,
+  })
+}
+
+afterEach(() => {
+  Object.defineProperty(global, 'strapi', {})
+})
+
+describe('config', () => {
+  it('default provider is dummy', () => {
+    setup({})
+
+    expect(strapi.config.get('plugin.translate').provider).toEqual('dummy')
+  })
+
+  it('setting translate relations to false', () => {
+    setup({ config: { translateRelations: false } })
+
+    expect(strapi.config.get('plugin.translate').translateRelations).toEqual(
+      false
+    )
+  })
+
+  it('changing translated field types', () => {
+    const translatedFieldTypes = [
+      'string',
+      { type: 'text', format: 'plain' },
+      { type: 'richtext', format: 'markdown' },
+      { type: 'ckeditor', format: 'html' },
+    ]
+    setup({ config: { translatedFieldTypes } })
+
+    expect(strapi.config.get('plugin.translate').translatedFieldTypes).toEqual(
+      translatedFieldTypes
+    )
+  })
+
+  it('fails with translated field types not array', () => {
+    const translatedFieldTypes = 'string'
+
+    expect(() => setup({ config: { translatedFieldTypes } })).toThrow(
+      'translatedFieldTypes has to be an array'
+    )
+  })
+
+  it('fails with translateRelations not a boolean', () => {
+    const translateRelations = 'false'
+
+    expect(() => setup({ config: { translateRelations } })).toThrow(
+      'translateRelations has to be a boolean'
+    )
+  })
+
+  it('fails with providerOptions not object or undefined', () => {
+    const providerOptions = 'Test'
+
+    expect(() => setup({ config: { providerOptions } })).toThrow(
+      'providerOptions has to be an object if it is defined'
+    )
+  })
+
+  it('fails with translated fields not being in correct schema', () => {
+    const translatedFieldTypes = [{ field: 'richtext' }]
+
+    expect(() => setup({ config: { translatedFieldTypes } })).toThrow(
+      'incorrect schema for translated fields'
+    )
+  })
+
+  it('fails with translated fields of unhandled field type', () => {
+    const translatedFieldTypes = [{ type: 'richtext', format: 'xml' }]
+
+    expect(() => setup({ config: { translatedFieldTypes } })).toThrow(
+      'unhandled format xml for translated field richtext'
+    )
+  })
+})

--- a/plugin/server/config/index.js
+++ b/plugin/server/config/index.js
@@ -4,11 +4,11 @@ module.exports = {
   default() {
     return {
       provider: 'dummy',
-      prodiverOptions: {},
+      providerOptions: {},
       translatedFieldTypes: [
-        'string',
-        'text',
-        'richtext',
+        { type: 'string', format: 'plain' },
+        { type: 'text', format: 'plain' },
+        { type: 'richtext', format: 'markdown' },
         'component',
         'dynamiczone',
       ],
@@ -21,13 +21,33 @@ module.exports = {
     translatedFieldTypes,
     translateRelations,
   }) {
-    if (provider === 'dummy') {
+    if (provider === 'dummy' && process.env.NODE_ENV !== 'test') {
       console.warn(
         'provider is set to dummy by default. This only copies all values'
       )
     }
     if (!Array.isArray(translatedFieldTypes)) {
       throw new Error('translatedFieldTypes has to be an array')
+    }
+    for (const field of translatedFieldTypes) {
+      if (typeof field === 'string') {
+        continue
+      } else if (typeof field === 'object') {
+        if (
+          typeof field.type !== 'string' ||
+          !['undefined', 'string'].includes(typeof field.format)
+        ) {
+          throw new Error('incorrect schema for translated fields')
+        }
+        if (
+          field.format &&
+          !['plain', 'markdown', 'html'].includes(field.format)
+        ) {
+          throw new Error(
+            `unhandled format ${field.format} for translated field ${field.type}`
+          )
+        }
+      }
     }
     if (typeof translateRelations !== 'boolean') {
       throw new Error('translateRelations has to be a boolean')

--- a/plugin/server/services/__tests__/format-service.test.js
+++ b/plugin/server/services/__tests__/format-service.test.js
@@ -1,0 +1,109 @@
+'use strict'
+
+const markdown = `# Turndown Demo
+
+This demonstrates [turndown](<https://github.com/mixmark-io/turndown>) \\- an HTML to Markdown converter in JavaScript.
+
+## Usage
+
+\`\`\`js
+var turndownService = new TurndownService()
+console.log(
+  turndownService.turndown('<h1>Hello world</h1>')
+)
+\`\`\`
+
+---
+
+It aims to be [CommonMark](<http://commonmark.org/>) compliant, and includes options to style the output. These options include:
+
+- headingStyle (setext or atx)
+- horizontalRule (\\*, -, or \\_)
+- bullet (\\*, -, or +)
+- codeBlockStyle (indented or fenced)
+
+
+List is separated
+
+- fence (\\\` or \\~)
+- emDelimiter (\\_ or \\*)
+- strongDelimiter (\\*\\* or \\_\\_)
+- linkStyle (inlined or referenced)
+- linkReferenceStyle (full, collapsed, or shortcut)
+
+
+End of Document`
+
+const html = `<h1>Turndown Demo</h1>
+<p>This demonstrates <a href="https://github.com/mixmark-io/turndown">turndown</a> - an HTML to Markdown converter in JavaScript.</p>
+<h2>Usage</h2>
+<pre><code class="js language-js">var turndownService = new TurndownService()
+console.log(
+  turndownService.turndown('&lt;h1&gt;Hello world&lt;/h1&gt;')
+)
+</code></pre>
+<hr />
+<p>It aims to be <a href="http://commonmark.org/">CommonMark</a> compliant, and includes options to style the output. These options include:</p>
+<ul>
+<li>headingStyle (setext or atx)</li>
+<li>horizontalRule (*, -, or _)</li>
+<li>bullet (*, -, or +)</li>
+<li>codeBlockStyle (indented or fenced)</li>
+</ul>
+<p>List is separated</p>
+<ul>
+<li>fence (\` or ~)</li>
+<li>emDelimiter (_ or *)</li>
+<li>strongDelimiter (** or __)</li>
+<li>linkStyle (inlined or referenced)</li>
+<li>linkReferenceStyle (full, collapsed, or shortcut)</li>
+</ul>
+<p>End of Document</p>`
+
+const setup = function (params) {
+  Object.defineProperty(global, 'strapi', {
+    value: require('../../../__mocks__/initSetup')(params),
+    writable: true,
+  })
+}
+
+beforeEach(() => {
+  setup({})
+})
+
+afterEach(() => {
+  Object.defineProperty(global, 'strapi', {})
+})
+
+describe('format', () => {
+  test('markdown to html', () => {
+    expect(
+      strapi.service('plugin::translate.format').markdownToHtml(markdown)
+    ).toEqual(html)
+  })
+  test('markdown to html in list', () => {
+    expect(
+      strapi.service('plugin::translate.format').markdownToHtml([markdown])
+    ).toEqual([html])
+  })
+  test('html to markdown in list', () => {
+    expect(
+      strapi.service('plugin::translate.format').htmlToMarkdown(html)
+    ).toEqual(markdown)
+    expect(
+      strapi.service('plugin::translate.format').htmlToMarkdown([html])
+    ).toEqual([markdown])
+  })
+  test('html to markdown and back', () => {
+    const formatService = strapi.service('plugin::translate.format')
+    expect(
+      formatService.markdownToHtml(formatService.htmlToMarkdown(html))
+    ).toEqual(html)
+  })
+  test('markdown to html and back', () => {
+    const formatService = strapi.service('plugin::translate.format')
+    expect(
+      formatService.htmlToMarkdown(formatService.markdownToHtml(markdown))
+    ).toEqual(markdown)
+  })
+})

--- a/plugin/server/services/format.js
+++ b/plugin/server/services/format.js
@@ -1,0 +1,36 @@
+'use strict'
+
+const showdown = require('showdown')
+const jsdom = require('jsdom')
+
+const dom = new jsdom.JSDOM()
+const showdownConverter = new showdown.Converter({
+  noHeaderId: true,
+  strikethrough: true,
+})
+
+function markdownToHtml(singleText) {
+  return showdownConverter.makeHtml(singleText)
+}
+
+function htmlToMarkdown(singleText) {
+  return showdownConverter
+    .makeMarkdown(singleText, dom.window.document)
+    .replace(/<!-- -->\n/g, '')
+    .trim()
+}
+
+module.exports = () => ({
+  markdownToHtml(text) {
+    if (Array.isArray(text)) {
+      return text.map(markdownToHtml)
+    }
+    return markdownToHtml(text)
+  },
+  htmlToMarkdown(text) {
+    if (Array.isArray(text)) {
+      return text.map(htmlToMarkdown)
+    }
+    return htmlToMarkdown(text)
+  },
+})

--- a/plugin/server/services/index.js
+++ b/plugin/server/services/index.js
@@ -5,6 +5,7 @@ const chunks = require('./chunks')
 const provider = require('./provider')
 const translate = require('./translate')
 const untranslated = require('./untranslated')
+const format = require('./format')
 
 module.exports = {
   'batch-translate-job': batchTranslateJob,
@@ -12,4 +13,5 @@ module.exports = {
   translate,
   untranslated,
   chunks,
+  format,
 }

--- a/plugin/server/utils/__tests__/translatable-fields.test.js
+++ b/plugin/server/utils/__tests__/translatable-fields.test.js
@@ -60,7 +60,7 @@ describe('translatable fields', () => {
       )
 
       // then
-      expect(translatedField).toEqual(attr)
+      expect(translatedField).toEqual({ field: attr, format: 'plain' })
     })
 
     it('text field copy not translated', async () => {
@@ -146,7 +146,9 @@ describe('translatable fields', () => {
       )
 
       // then
-      expect(translatedField).toEqual(['child_component.text'])
+      expect(translatedField).toEqual([
+        { field: 'child_component.text', format: 'markdown' },
+      ])
     })
 
     it('component with copy field not translated', async () => {
@@ -219,8 +221,8 @@ describe('translatable fields', () => {
 
       // then
       expect(translatedField).toEqual([
-        'child_component.0.text',
-        'child_component.1.text',
+        { field: 'child_component.0.text', format: 'markdown' },
+        { field: 'child_component.1.text', format: 'markdown' },
       ])
     })
 
@@ -256,9 +258,9 @@ describe('translatable fields', () => {
 
       // then
       expect(translatedField).toEqual([
-        'comp.text',
-        'comp.nested.text',
-        'comp.nested.nested.text',
+        { field: 'comp.text', format: 'plain' },
+        { field: 'comp.nested.text', format: 'plain' },
+        { field: 'comp.nested.nested.text', format: 'plain' },
       ])
     })
 
@@ -293,9 +295,9 @@ describe('translatable fields', () => {
 
       // then
       expect(translatedField).toEqual([
-        'dynamic_zone.0.text',
-        'dynamic_zone.1.title',
-        'dynamic_zone.2.text',
+        { field: 'dynamic_zone.0.text', format: 'markdown' },
+        { field: 'dynamic_zone.1.title', format: 'plain' },
+        { field: 'dynamic_zone.2.text', format: 'markdown' },
       ])
     })
   })
@@ -319,7 +321,7 @@ describe('translatable fields', () => {
       const translatedField = await getAllTranslatableFields(data, schema)
 
       // then
-      expect(translatedField).toEqual(['title'])
+      expect(translatedField).toEqual([{ field: 'title', format: 'plain' }])
     })
 
     it('complex content type translated', async () => {
@@ -359,13 +361,13 @@ describe('translatable fields', () => {
 
       // then
       expect(translatedField).toEqual([
-        'title',
-        'content',
-        'dynamic_zone.0.text',
-        'dynamic_zone.1.title',
-        'child_component.text',
-        'repeated_child_component.0.title',
-        'repeated_child_component.1.title',
+        { field: 'title', format: 'plain' },
+        { field: 'content', format: 'markdown' },
+        { field: 'dynamic_zone.0.text', format: 'markdown' },
+        { field: 'dynamic_zone.1.title', format: 'plain' },
+        { field: 'child_component.text', format: 'markdown' },
+        { field: 'repeated_child_component.0.title', format: 'plain' },
+        { field: 'repeated_child_component.1.title', format: 'plain' },
       ])
     })
   })

--- a/plugin/server/utils/translated-field-types.js
+++ b/plugin/server/utils/translated-field-types.js
@@ -1,0 +1,31 @@
+'use strict'
+
+function getFieldTypeConfig(type) {
+  const { translatedFieldTypes } = strapi.config.get('plugin.translate')
+
+  return translatedFieldTypes.find((t) => t === type || t.type === type)
+}
+
+function isTranslatedFieldType(type) {
+  return !!getFieldTypeConfig(type)
+}
+
+function getFieldTypeFormat(type) {
+  const typeConfig = getFieldTypeConfig(type)
+
+  if (typeof typeConfig === 'string') {
+    return 'plain'
+  } else {
+    return typeConfig.format
+  }
+}
+
+function isPlainFieldType(type) {
+  return getFieldTypeConfig(type) === 'plain'
+}
+
+module.exports = {
+  isTranslatedFieldType,
+  getFieldTypeFormat,
+  isPlainFieldType,
+}

--- a/providers/deepl/__mocks__/initStrapi.js
+++ b/providers/deepl/__mocks__/initStrapi.js
@@ -19,6 +19,7 @@ module.exports = ({ plugins = {} }) => {
         },
         services: {
           chunks: require('strapi-plugin-translate/server/services/chunks'),
+          format: require('strapi-plugin-translate/server/services/format'),
         },
       },
       'content-type-builder': {

--- a/providers/deepl/lib/__tests__/deepl.test.js
+++ b/providers/deepl/lib/__tests__/deepl.test.js
@@ -177,6 +177,25 @@ describe('deepl provider', () => {
             // then
             expect(result).toEqual(params.text)
           }
+
+          async function markdownTexts() {
+            // given
+            const params = {
+              sourceLocale: 'en',
+              targetLocale: 'de',
+              text: [
+                '# Heading\n\nSome text',
+                '## Subheading\n\nSome more text',
+              ],
+              format: 'markdown',
+            }
+            // when
+            const result = await deeplProvider.translate(params)
+
+            // then
+            expect(result).toEqual(params.text)
+          }
+
           async function forMissingText() {
             // given
             const params = {
@@ -215,6 +234,10 @@ describe('deepl provider', () => {
 
           it('with missing text', async () => {
             await forMissingText()
+          })
+
+          it('with markdown texts', async () => {
+            await markdownTexts()
           })
 
           it('with more than 50 texts', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4027,6 +4027,11 @@ JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
+abab@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.6.tgz#41b80f2c871d19686216b82309231cfd3cb3d291"
+  integrity sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==
+
 abbrev@^1.0.0, abbrev@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -4047,6 +4052,14 @@ accepts@^1.3.5, accepts@^1.3.7, accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.8:
     mime-types "~2.1.34"
     negotiator "0.6.3"
 
+acorn-globals@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/acorn-globals/-/acorn-globals-7.0.1.tgz#0dbf05c44fa7c94332914c02066d5beff62c40c3"
+  integrity sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==
+  dependencies:
+    acorn "^8.1.0"
+    acorn-walk "^8.0.2"
+
 acorn-import-assertions@^1.7.6:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz#ba2b5939ce62c238db6d93d81c9b111b29b855e9"
@@ -4057,12 +4070,12 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn-walk@^8.1.1:
+acorn-walk@^8.0.2, acorn-walk@^8.1.1:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1:
+acorn@^8.1.0, acorn@^8.4.1, acorn@^8.5.0, acorn@^8.7.1, acorn@^8.8.0:
   version "8.8.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.1.tgz#0a3f9cbecc4ec3bea6f0a80b66ae8dd2da250b73"
   integrity sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==
@@ -5744,7 +5757,7 @@ commander@^8.3.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-8.3.0.tgz#4837ea1b2da67b9c616a67afbb0fafee567bca66"
   integrity sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==
 
-commander@^9.1.0, commander@^9.3.0:
+commander@^9.0.0, commander@^9.1.0, commander@^9.3.0:
   version "9.4.1"
   resolved "https://registry.yarnpkg.com/commander/-/commander-9.4.1.tgz#d1dd8f2ce6faf93147295c0df13c7c21141cfbdd"
   integrity sha512-5EEkTNyHNGFPD2H+c/dXXfQZYa/scCKasxWcXJaWnNJ99pnQN9Vnmqow+p+PlFPE63Q6mThaZws1T+HxfpgtPw==
@@ -6200,6 +6213,23 @@ cssfilter@0.0.10:
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
 
+cssom@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.5.0.tgz#d254fa92cd8b6fbd83811b9fbaed34663cc17c36"
+  integrity sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==
+
+cssom@~0.3.6:
+  version "0.3.8"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.8.tgz#9f1276f5b2b463f2114d3f2c75250af8c1a36f4a"
+  integrity sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+
+cssstyle@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/cssstyle/-/cssstyle-2.3.0.tgz#ff665a0ddbdc31864b09647f34163443d90b0852"
+  integrity sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+  dependencies:
+    cssom "~0.3.6"
+
 csstype@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.1.tgz#841b532c45c758ee546a11d5bd7b7b473c8c30b9"
@@ -6235,6 +6265,15 @@ dashdash@^1.12.0:
   integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
   dependencies:
     assert-plus "^1.0.0"
+
+data-urls@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-3.0.2.tgz#9cf24a477ae22bcef5cd5f6f0bfbc1d2d3be9143"
+  integrity sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==
+  dependencies:
+    abab "^2.0.6"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
 
 date-fns@2.29.2:
   version "2.29.2"
@@ -6306,6 +6345,11 @@ decamelize@^1.1.0:
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
   integrity sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==
 
+decimal.js@^10.4.1:
+  version "10.4.2"
+  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.4.2.tgz#0341651d1d997d86065a2ce3a441fbd0d8e8b98e"
+  integrity sha512-ic1yEvwT6GuvaYwBLLY6/aFFgjZdySKTE8en/fkU3QICTmRtgtSlFn0u0BXN06InZwtfCelR7j8LRiDI/02iGA==
+
 decode-uri-component@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.0.tgz#eb3913333458775cb84cd1a1fae062106bb87545"
@@ -6333,7 +6377,7 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
-deep-is@^0.1.3:
+deep-is@^0.1.3, deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
@@ -6632,6 +6676,13 @@ domelementtype@^2.0.1, domelementtype@^2.2.0:
   resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
+domexception@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/domexception/-/domexception-4.0.0.tgz#4ad1be56ccadc86fc76d033353999a8037d03673"
+  integrity sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==
+  dependencies:
+    webidl-conversions "^7.0.0"
+
 domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-4.3.1.tgz#8d792033416f59d68bc03a5aa7b018c1ca89279c"
@@ -6796,6 +6847,11 @@ entities@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.2.0.tgz#098dc90ebb83d8dffa089d55256b351d34c4da55"
   integrity sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==
+
+entities@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-4.4.0.tgz#97bdaba170339446495e653cfd2db78962900174"
+  integrity sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -7080,6 +7136,18 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+escodegen@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.0.0.tgz#5e32b12833e8aa8fa35e1bf0befa89380484c7dd"
+  integrity sha512-mmHKys/C8BFUGI+MAWNcSYoORYLMdPzjrknd2Vc+bUsjN5bXcr8EhrNB+UTqfL1y3I9c4fw2ihgtMPQLBRiQxw==
+  dependencies:
+    esprima "^4.0.1"
+    estraverse "^5.2.0"
+    esutils "^2.0.2"
+    optionator "^0.8.1"
+  optionalDependencies:
+    source-map "~0.6.1"
+
 eslint-config-import@^0.13.0:
   version "0.13.0"
   resolved "https://registry.yarnpkg.com/eslint-config-import/-/eslint-config-import-0.13.0.tgz#082f3055e7ff651010526d35ac9a28ace438a544"
@@ -7288,7 +7356,7 @@ espree@^9.3.1:
     acorn-jsx "^5.3.1"
     eslint-visitor-keys "^3.3.0"
 
-esprima@^4.0.0, esprima@~4.0.0:
+esprima@^4.0.0, esprima@^4.0.1, esprima@~4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
@@ -7565,7 +7633,7 @@ fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
 
-fast-levenshtein@^2.0.6:
+fast-levenshtein@^2.0.6, fast-levenshtein@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
@@ -8601,6 +8669,13 @@ hpack.js@^2.1.6:
     readable-stream "^2.0.1"
     wbuf "^1.1.0"
 
+html-encoding-sniffer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz#2cb1a8cf0db52414776e5b2a7a04d5dd98158de9"
+  integrity sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==
+  dependencies:
+    whatwg-encoding "^2.0.0"
+
 html-entities@^2.1.0, html-entities@^2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/html-entities/-/html-entities-2.3.3.tgz#117d7626bece327fc8baace8868fa6f5ef856e46"
@@ -8767,6 +8842,14 @@ https-proxy-agent@^5.0.0:
     agent-base "6"
     debug "4"
 
+https-proxy-agent@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz#c59ef224a04fe8b754f3db0063a25ea30d0005d6"
+  integrity sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+
 human-signals@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
@@ -8811,7 +8894,7 @@ iconv-lite@0.4.24, iconv-lite@^0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@^0.6.2:
+iconv-lite@0.6.3, iconv-lite@^0.6.2:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -9357,6 +9440,11 @@ is-plain-object@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
   integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
+is-potential-custom-element-name@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz#171ed6f19e3ac554394edf78caa05784a45bebb5"
+  integrity sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==
 
 is-regex@^1.1.4:
   version "1.1.4"
@@ -10009,6 +10097,38 @@ jsbn@~0.1.0:
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
   integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
 
+jsdom@^20.0.2:
+  version "20.0.2"
+  resolved "https://registry.yarnpkg.com/jsdom/-/jsdom-20.0.2.tgz#65ccbed81d5e877c433f353c58bb91ff374127db"
+  integrity sha512-AHWa+QO/cgRg4N+DsmHg1Y7xnz+8KU3EflM0LVDTdmrYOc1WWTSkOjtpUveQH+1Bqd5rtcVnb/DuxV/UjDO4rA==
+  dependencies:
+    abab "^2.0.6"
+    acorn "^8.8.0"
+    acorn-globals "^7.0.0"
+    cssom "^0.5.0"
+    cssstyle "^2.3.0"
+    data-urls "^3.0.2"
+    decimal.js "^10.4.1"
+    domexception "^4.0.0"
+    escodegen "^2.0.0"
+    form-data "^4.0.0"
+    html-encoding-sniffer "^3.0.0"
+    http-proxy-agent "^5.0.0"
+    https-proxy-agent "^5.0.1"
+    is-potential-custom-element-name "^1.0.1"
+    nwsapi "^2.2.2"
+    parse5 "^7.1.1"
+    saxes "^6.0.0"
+    symbol-tree "^3.2.4"
+    tough-cookie "^4.1.2"
+    w3c-xmlserializer "^3.0.0"
+    webidl-conversions "^7.0.0"
+    whatwg-encoding "^2.0.0"
+    whatwg-mimetype "^3.0.0"
+    whatwg-url "^11.0.0"
+    ws "^8.9.0"
+    xml-name-validator "^4.0.0"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -10427,6 +10547,14 @@ levn@^0.4.1:
   dependencies:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
+
+levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
 
 libbase64@0.1.0:
   version "0.1.0"
@@ -11985,6 +12113,11 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+nwsapi@^2.2.2:
+  version "2.2.2"
+  resolved "https://registry.yarnpkg.com/nwsapi/-/nwsapi-2.2.2.tgz#e5418863e7905df67d51ec95938d67bf801f0bb0"
+  integrity sha512-90yv+6538zuvUMnN+zCr8LuV6bPFdq50304114vJYJ8RDyK8D5O9Phpbd6SZWgI7PwzmmfN1upeOJlvybDSgCw==
+
 oauth-sign@^0.9.0, oauth-sign@~0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
@@ -12194,6 +12327,18 @@ opener@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.2.tgz#5d37e1f35077b9dcac4301372271afdeb2a13598"
   integrity sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==
+
+optionator@^0.8.1:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 optionator@^0.9.1:
   version "0.9.1"
@@ -12485,6 +12630,13 @@ parse5@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-6.0.1.tgz#e1a1c085c569b3dc08321184f19a39cc27f7c30b"
   integrity sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
+parse5@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/parse5/-/parse5-7.1.1.tgz#4649f940ccfb95d8754f37f73078ea20afe0c746"
+  integrity sha512-kwpuwzB+px5WUg9pyK0IcK/shltJN5/OVhQagxhCQNtT9Y9QRZqNY2e1cmbu/paRh5LMnz/oVTVLBpjFmMZhSg==
+  dependencies:
+    entities "^4.4.0"
 
 parseurl@^1.3.2, parseurl@~1.3.2, parseurl@~1.3.3:
   version "1.3.3"
@@ -12787,6 +12939,11 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==
+
 prettier@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
@@ -12899,7 +13056,7 @@ proxy-from-env@^1.1.0:
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
-psl@^1.1.28:
+psl@^1.1.28, psl@^1.1.33:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
   integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
@@ -12983,6 +13140,11 @@ querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
   integrity sha512-X/xY82scca2tau62i9mDyU9K+I+djTMUsvwf7xnUX5GLvVzgJybOJf4Y6o9Zx3oJK/LSXg5tTZBjwzqVPaPO2g==
+
+querystringify@^2.1.1:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/querystringify/-/querystringify-2.2.0.tgz#3345941b4153cb9d082d8eee4cda2016a9aef7f6"
+  integrity sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -13859,6 +14021,13 @@ sanitize-html@2.7.1:
     parse-srcset "^1.0.2"
     postcss "^8.3.11"
 
+saxes@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/saxes/-/saxes-6.0.0.tgz#fe5b4a4768df4f14a201b1ba6a65c1f3d9988cc5"
+  integrity sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==
+  dependencies:
+    xmlchars "^2.2.0"
+
 scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
@@ -14142,6 +14311,13 @@ shebang-regex@^3.0.0:
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-3.0.0.tgz#ae16f1644d873ecad843b0307b143362d4c42172"
   integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
 
+showdown@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/showdown/-/showdown-2.1.0.tgz#1251f5ed8f773f0c0c7bfc8e6fd23581f9e545c5"
+  integrity sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==
+  dependencies:
+    commander "^9.0.0"
+
 side-channel@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/side-channel/-/side-channel-1.0.4.tgz#efce5c8fdc104ee751b25c58d4290011fa5ea2cf"
@@ -14347,7 +14523,7 @@ source-map@^0.5.0, source-map@^0.5.6, source-map@^0.5.7:
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
   integrity sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0:
+source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.0, source-map@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -14806,6 +14982,11 @@ symbol-observable@^1.0.4:
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
+symbol-tree@^3.2.4:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
+  integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+
 tapable@^2.0.0, tapable@^2.1.1, tapable@^2.2.0, tapable@^2.2.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-2.2.1.tgz#1967a73ef4060a82f12ab96af86d52fdb76eeca0"
@@ -15048,12 +15229,29 @@ toposort@^2.0.2:
   resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
   integrity sha1-riF2gXXRVZ1IvvNUILL0li8JwzA=
 
+tough-cookie@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-4.1.2.tgz#e53e84b85f24e0b65dd526f46628db6c85f6b874"
+  integrity sha512-G9fqXWoYFZgTc2z8Q5zaHy/vJMjm+WV0AkAeHxVCQiEB1b+dGvWzFW6QV07cY5jQ5gRkeid2qIkzkxUnmoQZUQ==
+  dependencies:
+    psl "^1.1.33"
+    punycode "^2.1.1"
+    universalify "^0.2.0"
+    url-parse "^1.5.3"
+
 tough-cookie@~2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
   integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
   dependencies:
     psl "^1.1.28"
+    punycode "^2.1.1"
+
+tr46@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-3.0.0.tgz#555c4e297a950617e8eeddef633c87d4d9d6cbf9"
+  integrity sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==
+  dependencies:
     punycode "^2.1.1"
 
 tr46@~0.0.3:
@@ -15153,6 +15351,13 @@ type-check@^0.4.0, type-check@~0.4.0:
   integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
   dependencies:
     prelude-ls "^1.2.1"
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-detect@4.0.8:
   version "4.0.8"
@@ -15335,6 +15540,11 @@ universalify@^0.1.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
 
+universalify@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/universalify/-/universalify-0.2.0.tgz#6451760566fa857534745ab1dde952d1b1761be0"
+  integrity sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==
+
 universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
@@ -15404,6 +15614,14 @@ url-join@4.0.1, url-join@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/url-join/-/url-join-4.0.1.tgz#b642e21a2646808ffa178c4c5fda39844e12cde7"
   integrity sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==
+
+url-parse@^1.5.3:
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
+  dependencies:
+    querystringify "^2.1.1"
+    requires-port "^1.0.0"
 
 url@^0.11.0:
   version "0.11.0"
@@ -15539,6 +15757,13 @@ vm-browserify@^1.1.2:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+w3c-xmlserializer@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/w3c-xmlserializer/-/w3c-xmlserializer-3.0.0.tgz#06cdc3eefb7e4d0b20a560a5a3aeb0d2d9a65923"
+  integrity sha512-3WFqGEgSXIyGhOmAFtlicJNMjEps8b1MG31NCA0/vOF9+nKMUW1ckhi9cnNHmf88Rzw5V+dwIwsm2C7X8k9aQg==
+  dependencies:
+    xml-name-validator "^4.0.0"
+
 walk-up-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/walk-up-path/-/walk-up-path-1.0.0.tgz#d4745e893dd5fd0dbb58dd0a4c6a33d9c9fec53e"
@@ -15586,6 +15811,11 @@ webidl-conversions@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
+
+webidl-conversions@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
+  integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
 
 webpack-cli@^4.10.0:
   version "4.10.0"
@@ -15726,6 +15956,13 @@ websocket-extensions@>=0.1.1:
   resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
   integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
+whatwg-encoding@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz#e7635f597fd87020858626805a2729fa7698ac53"
+  integrity sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==
+  dependencies:
+    iconv-lite "0.6.3"
+
 whatwg-fetch@^3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
@@ -15735,6 +15972,14 @@ whatwg-mimetype@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz#5fa1a7623867ff1af6ca3dc72ad6b8a4208beba7"
   integrity sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==
+
+whatwg-url@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-11.0.0.tgz#0a849eebb5faf2119b901bb76fd795c2848d4018"
+  integrity sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==
+  dependencies:
+    tr46 "^3.0.0"
+    webidl-conversions "^7.0.0"
 
 whatwg-url@^5.0.0:
   version "5.0.0"
@@ -15824,7 +16069,7 @@ winston@3.3.3:
     triple-beam "^1.3.0"
     winston-transport "^4.4.0"
 
-word-wrap@^1.0.3, word-wrap@^1.2.3:
+word-wrap@^1.0.3, word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
   integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
@@ -15885,10 +16130,25 @@ ws@^8.4.2:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.10.0.tgz#00a28c09dfb76eae4eb45c3b565f771d6951aa51"
   integrity sha512-+s49uSmZpvtAsd2h37vIPy1RBusaLawVe8of+GyEPsaJTCMpj/2v8NpeK1SHXjBlQ95lQTmQofOJnFiLoaN3yw==
 
+ws@^8.9.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.11.0.tgz#6a0d36b8edfd9f96d8b25683db2f8d7de6e8e143"
+  integrity sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==
+
 xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml-name-validator@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-4.0.0.tgz#79a006e2e63149a8600f15430f0a4725d1524835"
+  integrity sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==
+
+xmlchars@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
+  integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
 
 xss@^1.0.6, xss@^1.0.8:
   version "1.0.14"


### PR DESCRIPTION
Since some providers do not handle Markdown or HTML out of the box, this feature enables the configuration and handling of different text formats. There are 3 different formats defined: plain,
markdown and html.
On translation fields are grouped by their format and submitted per format to the provider.
Providers can either translate the text in the respective format or optionally parse them to a format supported by them. There is a new service defined, that allows the parsing between html and markdown.

BREAKING CHANGE: Translate service api requires array of objects of shape {field:string,format:string} instead of just the field as string

fix #25